### PR TITLE
自宅Growi用のElasticSearchイメージを作成した

### DIFF
--- a/utils/growi/elasticsearch-for-growi/Dockerfile
+++ b/utils/growi/elasticsearch-for-growi/Dockerfile
@@ -1,0 +1,5 @@
+ARG version=8.10.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:${version}
+
+RUN bin/elasticsearch-plugin install analysis-kuromoji
+RUN bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION


# 動作確認

`docker run -p 9200:9200 -p 9300:9300  -e "discovery.type=single-node"  -e "xpack.security.enabled=false" elasticsearch-for-growi`

している状態で、ESサーバーが動いていることを以下の通り確かめた。

```
$ curl -X GET -s "localhost:9200/_cat/nodes"
172.18.0.2 22 96 0 0.61 0.29 0.22 cdfhilmrstw * 823a05d3b75e
```

イメージは　public.ecr.aws/i2c5f4g8/home-growi/elasticsearch-for-growi:latest　にpush済み
