### PR TITLE
GrowiのためのElasticSearchをデプロイするmanifestを追加

### DIFF
--- a/growi/growi-elasticsearch.yml
+++ b/growi/growi-elasticsearch.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: growi-elasticsearch
+  namespace: growi
+spec:
+  ports:
+    - port: 9200
+  selector:
+    app: elasticsearch
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  namespace: growi
+spec:
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - image: public.ecr.aws/i2c5f4g8/home-growi/elasticsearch-for-growi:latest
+          name: elasticsearch
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+          ports:
+            - containerPort: 9200
+              name: elasticsearch


### PR DESCRIPTION
ElasticSearchの動作確認をしたのでES部分をデプロイする

# 動作確認


` kubectl port-forward -n growi svc/growi-elasticsearch 9200:9200`

```
$ curl localhost:9200
{
  "name" : "elasticsearch-69847b57b5-xnsvd",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "3K_kmPFXSw-IAacxOP_asA",
  "version" : {
    "number" : "8.10.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "6d20dd8ce62365be9b1aca96427de4622e970e9e",
    "build_date" : "2023-09-19T08:16:24.564900370Z",
    "build_snapshot" : false,
    "lucene_version" : "9.7.0",
    "minimum_wire_compatibility_version" : "7.17.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "You Know, for Search"
}
```