### PR TITLE
Growiのmanifestを追加

### DIFF
--- a/growi/growi-growi.yml
+++ b/growi/growi-growi.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: growi
+  namespace: growi
+spec:
+  ports:
+    - port: 3000
+  selector:
+    app: growi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: growi
+  namespace: growi
+spec:
+  selector:
+    matchLabels:
+      app: growi
+  template:
+    metadata:
+      labels:
+        app: growi
+    spec:
+      containers:
+        - image: weseek/growi:6.2.1
+          name: growi
+          env:
+            - name: MONGO_URI
+              value: mongodb://growi-machine-user:password@growi-mongodb:27017/growi
+            - name: ELASTICSEARCH_URI
+              value: http://growi-elasticsearch:9200/growi
+          ports:
+            - containerPort: 3000
+              name: growi


### PR DESCRIPTION
# 前提条件

mongoDBに以下のユーザーが存在している必要がある
```
growi> db.createUser( { user:"growi-machine-user", pwd:"password", roles: [ { role: "readWrite", db: "growi" } ] } )
```


# 動作確認

rootで入り、growi用マシンユーザーを作成した。

```
admin> use growi
switched to db growi
growi> db.createUser( { user:"growi-machine-user", pwd:"password", roles: [ { role: "readWrite", db: "growi" } ] } )
```

` kubectl port-forward -n growi svc/growi 3000:3000` で動作確認


ブラウザでlocalhost:3000 を開いた
![image](https://github.com/yuchiki/test-manifests/assets/14884013/bb5f6fe0-f64a-4136-9a72-4da345d98edf)
