### PR TITLE
growiのパラメータ調整/routing

### DIFF
--- a/growi/growi-growi.yml
+++ b/growi/growi-growi.yml
@@ -31,6 +31,8 @@ spec:
               value: mongodb://growi-machine-user:password@growi-mongodb:27017/growi
             - name: ELASTICSEARCH_URI
               value: http://growi-elasticsearch:9200/growi
+            - name: PASSWORD_SEED
+              value: changeme
           ports:
             - containerPort: 3000
               name: growi

--- a/growi/growi-routing.yml
+++ b/growi/growi-routing.yml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: growi-http-route
+  namespace: growi
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: istio-gateway
+      sectionName: default
+  hostnames: ["growi.yuchiki.net"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: growi
+          port: 3000


### PR DESCRIPTION
1. growiがログインできない問題の解決

https://docs.growi.org/ja/admin-guide/management-cookbook/export.html#%E3%83%86%E3%82%99%E3%83%BC%E3%82%BF%E3%82%A2%E3%83%BC%E3%82%AB%E3%82%A4%E3%83%95%E3%82%99%E6%96%B9%E6%B3%95 に従って、 SEED値を設定した

2. routeの作成

`curl -H "Host: growi.yuchiki.net" ほにゃらか:8080/` で動作確認済み