### PR TITLE
家庭内DNSを構築

### DIFF
--- a/home-dns/Corefile
+++ b/home-dns/Corefile
@@ -1,0 +1,21 @@
+(default) {
+    forward . 8.8.8.8
+    errors
+    log
+    cache
+}
+
+home {
+   hosts {
+    192.168.40.1 router.home
+    192.168.40.2 yurichikiserver.home
+    192.168.40.2 growi.home
+    192.168.40.2 factorio.home
+    fallthrough
+   }
+   import default
+}
+
+. {
+    import default
+}

--- a/home-dns/home-dns-deployment.yaml
+++ b/home-dns/home-dns-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home-dns-deployment
+  namespace: home-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns
+  template:
+    metadata:
+      labels:
+        app: coredns
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.10.1
+          args:
+            - -conf
+            - /etc/coredns/Corefile
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns-config

--- a/home-dns/home-dns-namespace.yaml
+++ b/home-dns/home-dns-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home-dns

--- a/home-dns/home-dns-service.yaml
+++ b/home-dns/home-dns-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-dns
+  namespace: home-dns
+spec:
+  type: NodePort
+  selector:
+    app: coredns
+  ports:
+    - name: dns
+      port: 53
+      nodePort: 30053
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      nodePort: 30053

--- a/home-dns/kustomization.yaml
+++ b/home-dns/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- ./home-dns-namespace.yaml
+- ./home-dns-deployment.yaml
+- ./home-dns-service.yaml
+
+configMapGenerator:
+- name: coredns-config
+  namespace: home-dns
+  files:
+  - Corefile
+


### PR DESCRIPTION
# 概要

自宅内DNSサーバーを作成した。

# 使っている技術

- coredns
  - https://coredns.io/manual/toc/
  - DNSサーバーアプリ
  - corednsという設定ファイルで設定 
- kustomize機能
  - https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
  - configmapをCorefileから生成するために使用
  - manifestをコード生成する機能`
  - 元々は独立したコマンドだが、-k でkubectlにも機能として組み込まれている
  - argoCDにも対応
    - https://kakakakakku.hatenablog.com/entry/2021/08/30/121815 

# 動作確認


- kustomizeをインストールする
- 以下のコマンドを実施して、ファイルからconfigmapを作成し、apply した。

```
$ kubectl apply -k home-dns 
```

LAN内外のDNSが正しく引けていることを確認

```
$ dig google.com -p 30053 @192.168.40.2 +short
172.217.175.110
$ dig yurichikiserver.home -p 30053 @192.168.40.2 +short
192.168.40.2
$ dig router.home -p 30053 @192.168.40.2 +short
192.168.40.1
 dig growi.home -p 30053 @192.168.40.2 +short
192.168.40.2
```

## マージ後作業

それぞれのマシンが使っているローカルのwifi接続の設定で、つなげるDNSサーバーのprimaryを192.168.40.2:30053にすれば機能する