### PR TITLE
yurichiki鯖の家庭用ページを設定＆.homeで受け付けるようにした

### DIFF
--- a/argo-cd/argo-cd-http-route.yaml
+++ b/argo-cd/argo-cd-http-route.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: argocd
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: istio-gateway
+      sectionName: home
+  hostnames: ["argocd.home"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argocd-server
+          port: 80

--- a/gateway/gateway.yaml
+++ b/gateway/gateway.yaml
@@ -20,7 +20,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: home # TODO: TLS サポート
+    - name: home # TODO: TLS サポート。argocdがHTTPをHTTPSにリダイレクトするので、TLSをサポートする必要がある。
       hostname: "*.home"
       port: 80
       protocol: HTTP

--- a/gateway/gateway.yaml
+++ b/gateway/gateway.yaml
@@ -20,3 +20,11 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: home # TODO: TLS サポート
+      hostname: "*.home"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+

--- a/growi/growi-routing.yml
+++ b/growi/growi-routing.yml
@@ -17,3 +17,23 @@ spec:
       backendRefs:
         - name: growi
           port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: growi-http-route-internal
+  namespace: growi
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: istio-gateway
+      sectionName: home
+  hostnames: ["growi.home"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: growi
+          port: 3000

--- a/home-dns/Corefile
+++ b/home-dns/Corefile
@@ -10,6 +10,7 @@ home {
     192.168.40.1 router.home
     192.168.40.2 yurichikiserver.home
     192.168.40.2 growi.home
+    192.168.40.2 argocd.home
     192.168.40.2 factorio.home
     fallthrough
    }

--- a/yurichikiserver/yurichikierver-service.yaml
+++ b/yurichikiserver/yurichikierver-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-service
+  name: yurichikiserver-service
+  namespace: yurichikiserver
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: nginx
   ports:
     - port: 80
       targetPort: 80
-      nodePort: 30001

--- a/yurichikiserver/yurichikiserver-deployment.yaml
+++ b/yurichikiserver/yurichikiserver-deployment.yaml
@@ -1,12 +1,13 @@
 apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: yurichikiserver-deployment
+  namespace: yurichikiserver
 spec:
   selector:
     matchLabels:
       app: nginx
-  replicas: 2 # tells deployment to run 2 pods matching the template
+  replicas: 1 # tells deployment to run 2 pods matching the template
   template:
     metadata:
       labels:

--- a/yurichikiserver/yurichikiserver-httproute.yaml
+++ b/yurichikiserver/yurichikiserver-httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: yurichikiserver
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: istio-gateway
+      sectionName: home
+  hostnames: ["yurichikiserver.home"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: yurichikiserver-service
+          port: 80

--- a/yurichikiserver/yurichikiserver-namespace.yaml
+++ b/yurichikiserver/yurichikiserver-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: yurichikiserver


### PR DESCRIPTION
# 概要
gateway API が外から .home に向けて飛んできた port 80トラフィックもさばけるようにした
外からは AWS の ALBではじいている+ port 8080に向けて飛んでくるので、.homeにはアクセスできない

# 確認

- http://growi.home
- http://yurichikiserver.home 
に家庭内LANからアクセスできる


# 備考
- argocdは80を443/httpsにリダイレクトするので、まだargocdではアクセスできない
- 作業に応じてargocdのauto syncをいくつか無効にしているので、後で有効に戻す