### PR TITLE
http3に対応する設定を追加s

### DIFF
--- a/istio/istio-operator.yaml
+++ b/istio/istio-operator.yaml
@@ -1,0 +1,32 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: install
+spec:
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        service:
+          ports:
+          - name: status-port
+            port: 15021
+            targetPort: 15021
+          # Both HTTPS and HTTP/3 must have
+          # the same port number. Here it
+          # is 443/TCP and 443/UDP
+          - name: https
+            port: 443
+            targetPort: 8443
+          - name: http3
+            port: 443
+            targetPort: 8443
+            protocol: UDP
+values:
+  pilot:
+    # This is required to create mirror QUIC
+    # listeners for TLS-terminated HTTPS listeners
+    # on the gateway
+    env:
+      PILOT_ENABLE_QUIC_LISTENERS: true


### PR DESCRIPTION
https://github.com/istio/istio/wiki/Experimental-QUIC-and-HTTP-3-support-in-Istio-gateways