### PR TITLE
cloudflareの設定ファイルのインデントを直す

### DIFF
--- a/cloudflare/cloudflared.yaml
+++ b/cloudflare/cloudflared.yaml
@@ -92,8 +92,8 @@ data:
       originRequest:
           httpHostHeader: growi.yuriacats.net
     - hostname: growi.yurichiki.click
-        service: http://gateway-istio.istio-ingress.svc.cluster.local:8080
-        originRequest:
-            httpHostHeader: growi.yurichiki.click
+      service: http://gateway-istio.istio-ingress.svc.cluster.local:8080
+      originRequest:
+          httpHostHeader: growi.yurichiki.click
     # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
     - service: http_status:404


### PR DESCRIPTION
現状、istio-ingressが正しく更新されていない
- 他のpodからistio-ingress目掛けてcurlして、 growi.yuriacats.netは通って growi.yurichiki.clickは通らないことを確かめた）

それはそれとして...その外側の cloudlflareも設定ファイルのインデントがミスっててpod deployに失敗していたので修正