### PR TITLE
growiのバージョンを6.3から7.0にあげる

### DIFF
--- a/growi/growi-growi.yml
+++ b/growi/growi-growi.yml
@@ -26,7 +26,7 @@ spec:
         app: growi
     spec:
       containers:
-        - image: weseek/growi:6.3
+        - image: weseek/growi:7.0
           name: growi
           env:
             - name: MONGO_URI


### PR DESCRIPTION
資料： https://docs.growi.org/ja/admin-guide/upgrading/70x.html