### PR TITLE
argocdが別ブランチを見ていたのでmasterブランチを見るように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # yurichikiserver Manifest
+


### PR DESCRIPTION
確認すること
1. argocdにログインして各リポジトリの参照先ブランチが `master`になっていることを確認